### PR TITLE
Reproduction gripper too forcefully and add hard-code logic to handle 0/1 gripper value's gripper open/close logic

### DIFF
--- a/benchmark/envs/cogact_demo_env.py
+++ b/benchmark/envs/cogact_demo_env.py
@@ -53,10 +53,13 @@ class CogActDemoEnv(DemoEnv):
         # init task_file
         self.load(task_file)
         self.load_task_setup()
-        self.gripper_operation_enabled = True  # Enable gripper operation by default
-        self.gripper_operated_count = 0  # Count how many times the gripper has been operated
-        self.gripper_operated_threshold = 16 # After how many executions the gripper will be enable to operate again
-        
+        self.right_gripper_close_enabled = True  # Enable gripper operation by default
+        self.right_gripper_closed_count = 0  # Count how many times the gripper has been operated
+        self.right_gripper_closed_threshold = 16 # After how many executions the gripper will be enable to operate again
+        self.left_gripper_close_enabled = True  # Enable gripper operation by default
+        self.left_gripper_closed_count = 0  # Count how many times the gripper has been operated
+        self.left_gripper_closed_threshold = 16 # After how many executions the gripper will be enable to operate again
+
     def get_observation(self):
         """
         # Example
@@ -226,22 +229,19 @@ class CogActDemoEnv(DemoEnv):
 
     def _robot_move(self, actions):
         # handle gripper close/open enable flag
-        if self.gripper_operated_count >= self.gripper_operated_threshold:
-            self.gripper_operated_count = 0  # Reset count after threshold is reached
+        if not self.right_gripper_close_enabled and self.right_gripper_closed_count >= self.right_gripper_closed_threshold:
+            self.right_gripper_close_enabled = True
             logger.logger.info(
-                f"Gripper operation count reset to {self.gripper_operated_count}."
+                f"Right gripper operation reset enabled."
             )
-        if self.gripper_operated_count == 0:
-            self.gripper_operation_enabled = True
+        self.right_gripper_closed_count += 1
+        
+        if not self.left_gripper_close_enabled and self.left_gripper_closed_count >= self.left_gripper_closed_threshold:
+            self.left_gripper_close_enabled = True
             logger.logger.info(
-                f"Gripper operation enabled after {self.gripper_operated_threshold} steps."
+                f"Left gripper operation reset enabled."
             )
-        else:
-            self.gripper_operation_enabled = False
-            logger.logger.info(
-                f"Gripper operation disabled, operated count: {self.gripper_operated_count}"
-            )
-        self.gripper_operated_count += 1
+        self.left_gripper_closed_count += 1
 
         move_type = (
             "Normal"  # "Normal", "AvoidObs" # Normal is much more fast than AvoidObs
@@ -266,36 +266,46 @@ class CogActDemoEnv(DemoEnv):
             target_left_ee_pose, type=move_type, arm="left", block=True
         )
         
-        if not self.gripper_operation_enabled:
-            logger.logger.warning("Gripper operation is currently disabled.")
-            return
+       
+        # move gripper
+        right_gripper_action = actions["ROBOT_RIGHT_GRIPPER"][0]
+        # right_gripper_action = 0
+        if right_gripper_action > 0.5:
+            # right_gripper_action = "open"
+            # self.robot.set_gripper_action(right_gripper_action, arm="right")
+            # self.robot.open_gripper("right")
+            self._operate_gripper("right", right_gripper_action)
         else:
-            # move gripper
-            right_gripper_action = actions["ROBOT_RIGHT_GRIPPER"][0]
-            # right_gripper_action = 0
-            if right_gripper_action > 0.5:
-                # right_gripper_action = "open"
-                # self.robot.set_gripper_action(right_gripper_action, arm="right")
-                # self.robot.open_gripper("right")
-                self._operate_gripper("right", right_gripper_action)
+            if not self.right_gripper_close_enabled:
+                logger.logger.warning("[RIGHT] Gripper operation is currently disabled.")
+                return
             else:
                 # right_gripper_action = "close"
                 # self.robot.set_gripper_action(right_gripper_action, arm="right")
                 # self.robot.close_gripper("right")
-                logger.logger.info("Close gripper")
+                logger.logger.info("Close right gripper")
                 self._operate_gripper("right", right_gripper_action)
+                self.right_gripper_close_enabled = False
+                self.right_gripper_closed_count = 0  # Reset count after operation
 
-            left_gripper_action = actions["ROBOT_LEFT_GRIPPER"][0]
-            if left_gripper_action > 0.5:
-                # left_gripper_action = "open"
-                # self.robot.set_gripper_action(left_gripper_action, arm="left")
-                # self.robot.open_gripper("left")
-                self._operate_gripper("left", right_gripper_action)
+        left_gripper_action = actions["ROBOT_LEFT_GRIPPER"][0]
+        if left_gripper_action > 0.5:
+            # left_gripper_action = "open"
+            # self.robot.set_gripper_action(left_gripper_action, arm="left")
+            # self.robot.open_gripper("left")
+            self._operate_gripper("left", right_gripper_action)
+        else:
+            if not self.left_gripper_close_enabled:
+                logger.logger.warning("[LEFT] Gripper operation is currently disabled.")
+                return
             else:
                 # left_gripper_action = "close"
                 # self.robot.set_gripper_action(left_gripper_action, arm="left")
                 # self.robot.close_gripper("left")
+                logger.logger.info("Close left gripper")
                 self._operate_gripper("left", right_gripper_action)
+                self.left_gripper_close_enabled = False
+                self.left_gripper_closed_count = 0  # Reset count after operation
 
     def _operate_gripper(self, gripper_type: str, gripper_value):
         """    def set_init_pose(self, init_pose):

--- a/benchmark/envs/cogact_demo_env.py
+++ b/benchmark/envs/cogact_demo_env.py
@@ -114,7 +114,65 @@ class CogActDemoEnv(DemoEnv):
         # # Use mode 'wb' (write binary) when writing with pickle
         # with open('head_cam_and_link_pitch_head.pkl', 'wb') as f:
         #     pickle.dump(log_data, f)
-
+        """
+        list(observation_raw['joint'].keys())
+        [
+            'idx01_body_joint1', 
+            'idx02_body_joint2', 
+            'idx11_head_joint1', 
+            'idx12_head_joint2', 
+            'idx21_arm_l_joint1', 
+            'idx61_arm_r_joint1', 
+            'idx22_arm_l_joint2', 
+            'idx62_arm_r_joint2', 
+            'idx23_arm_l_joint3', 
+            'idx63_arm_r_joint3',
+            'idx24_arm_l_joint4', 
+            'idx64_arm_r_joint4',
+            'idx25_arm_l_joint5', 
+            'idx65_arm_r_joint5', 
+            'idx26_arm_l_joint6', 
+            'idx66_arm_r_joint6', 
+            'idx27_arm_l_joint7', 
+            'idx67_arm_r_joint7', 
+            'idx31_gripper_l_inner_joint1', 
+            'idx41_gripper_l_outer_joint1', 
+            'idx71_gripper_r_inner_joint1', 
+            'idx81_gripper_r_outer_joint1', 
+            'idx32_gripper_l_inner_joint3', 
+            'idx42_gripper_l_outer_joint3', 
+            'idx72_gripper_r_inner_joint3', 
+            'idx82_gripper_r_outer_joint3', 
+            'idx33_gripper_l_inner_joint4', 
+            'idx43_gripper_l_outer_joint4', 
+            'idx73_gripper_r_inner_joint4', 
+            'idx83_gripper_r_outer_joint4', 
+            'idx54_gripper_l_inner_joint0', 
+            'idx53_gripper_l_outer_joint0', 
+            'idx94_gripper_r_inner_joint0', 
+            'idx93_gripper_r_outer_joint0']
+            
+        list(observation_raw['joint'].keys())[19]: 'idx41_gripper_l_outer_joint1'
+        list(observation_raw['joint'].keys())[21]: 'idx81_gripper_r_outer_joint1'
+        """
+        """
+        {
+            'camera': {}, 
+            'joint': 
+            {
+                'idx01_body_joint1': 0.2700676918029785, 
+                'idx02_body_joint2': 0.5237442255020142,  ...}, 
+            'pose': {
+                '/G1/head_link2/Head_Camera': {...}}, 
+                'gripper': {'left': {...}, 'right': {...}}, 
+                'right_ee_pose': array([[ 0.88513639, -0.45113999,  0.11404508, -4.51743698],
+                    [-0.36640036, -0.52461625,  0.76845857, 10.86233616],
+                    [-0.28685249, -0.7219768 , -0.62965479,  0.97332233],
+                    [ 0.        ,  0.        ,  0.        ,  1.        ]]), 
+                'left_ee_pose': array([[-0.88493367, -0.45251531,  0.11010131, -4.51798534],
+                    [-0.36348256,  0.52329309, -0.770743  , 11.69530678],
+                    [ 0.29115776, -0.72207633, -0.6275611 ,  0.97288483],
+                    [ 0.        ,  0.        ,  0.        ,  1.        ]])}"""
         observation_raw["right_ee_pose"] = right_ee_pose2
         observation_raw["left_ee_pose"] = left_ee_pose2
         return observation_raw
@@ -214,7 +272,7 @@ class CogActDemoEnv(DemoEnv):
             # self.robot.close_gripper("left")
             self._operate_gripper("left", right_gripper_action)
 
-    def _operate_gripper(self, type: str, gripper_value):
+    def _operate_gripper(self, gripper_type: str, gripper_value):
         """    def set_init_pose(self, init_pose):
         target_joint_position = []
         target_joint_indices = []
@@ -257,17 +315,65 @@ class CogActDemoEnv(DemoEnv):
 
         # gripper_pos = min(0.8, max(0.0, gripper_value))
         if gripper_value > 0.5:
-            gripper_pos = 0.8
-        else:
-            gripper_pos = 0
-        print(f"{type} gripper: {gripper_value}")
-        gripper_joint_idx = 19 if type == "left" else 21
+            gripper_pos = 0.8 # open
+            print(f"{gripper_type} gripper: {gripper_value}")
+            gripper_joint_idx = 19 if gripper_type == "left" else 21
 
-        self.robot.client.set_joint_positions(
-            target_joint_position=[gripper_pos],
-            is_trajectory=False,
-            joint_indices=[gripper_joint_idx],
-        )
+            self.robot.client.set_joint_positions(
+                target_joint_position=[gripper_pos],
+                is_trajectory=False,
+                joint_indices=[gripper_joint_idx],
+            )
+        else:
+            gripper_pos = 0 # close
+            self._gentle_close_gripper(gripper_type)
+    def _gentle_close_gripper(self, gripper_type: str):
+        """
+        Gently close the gripper to avoid damaging objects.
+        """
+        if gripper_type == "left":
+            gripper_joint_idx = 19
+        else:
+            gripper_joint_idx = 21
+
+        # Set a gentle close position delta, e.g., 0.1
+        # This is to avoid damaging objects by closing too hard
+        gentle_close_position_delta = 0.1
+        # Get the current position of the gripper
+        cur_obs = self.get_observation()
+        current_position = cur_obs['joint'][list(cur_obs['joint'].keys())[gripper_joint_idx]]
+        # Calculate the gentle close positions, each time close delta, end position should close to 0
+        def generate_decreasing_range(current_value, min_value, delta):
+            """
+            Generate a NumPy array from current_value down to (and including) min_value,
+            decreasing by delta each step.
+            
+            Args:
+                current_value (float): Starting value.
+                min_value (float): Minimum value to reach.
+                delta (float): Step size (positive number).
+            
+            Returns:
+                np.ndarray: Decreasing values from current_value to min_value.
+            """
+            if delta <= 0:
+                raise ValueError("delta must be positive")
+
+            # np.arange excludes the endpoint, so we subtract a small epsilon to include min_value
+            return np.arange(current_value, min_value - 1e-8, -delta)
+        gentle_closed_postion = 0.01  # Set a gentle close position, e.g., 0.01
+        if current_position > gentle_closed_postion:
+            gentle_close_positions = generate_decreasing_range(
+                current_value=current_position,
+                min_value=gentle_closed_postion,
+                delta=gentle_close_position_delta
+            )
+            print(f"Gently closing {gripper_type} gripper in {len(gentle_close_positions)} steps from {current_position} to 0.01 with delta {gentle_close_position_delta}")
+            self.robot.client.set_joint_positions(
+                target_joint_position=gentle_close_positions,
+                is_trajectory=True,
+                joint_indices=[gripper_joint_idx],
+            )
 
     def _get_per_step_actions(self, actions, step_id):
         """
@@ -291,7 +397,7 @@ class CogActDemoEnv(DemoEnv):
         self.current_step += 1
         action_len = len(actions["ROBOT_RIGHT_POSE_IN_HEAD_CAM"])
 
-        execute_K = min(1, action_len)
+        execute_K = min(4, action_len)
         execute_step_N = 1
         for execute_step_id in range(execute_K):
             is_first_or_last = execute_step_id == 0 or execute_step_id == execute_K - 1

--- a/benchmark/envs/cogact_demo_env.py
+++ b/benchmark/envs/cogact_demo_env.py
@@ -53,7 +53,10 @@ class CogActDemoEnv(DemoEnv):
         # init task_file
         self.load(task_file)
         self.load_task_setup()
-
+        self.gripper_operation_enabled = True  # Enable gripper operation by default
+        self.gripper_operated_count = 0  # Count how many times the gripper has been operated
+        self.gripper_operated_threshold = 16 # After how many executions the gripper will be enable to operate again
+        
     def get_observation(self):
         """
         # Example
@@ -222,6 +225,24 @@ class CogActDemoEnv(DemoEnv):
         return ee_pose
 
     def _robot_move(self, actions):
+        # handle gripper close/open enable flag
+        if self.gripper_operated_count >= self.gripper_operated_threshold:
+            self.gripper_operated_count = 0  # Reset count after threshold is reached
+            logger.logger.info(
+                f"Gripper operation count reset to {self.gripper_operated_count}."
+            )
+        if self.gripper_operated_count == 0:
+            self.gripper_operation_enabled = True
+            logger.logger.info(
+                f"Gripper operation enabled after {self.gripper_operated_threshold} steps."
+            )
+        else:
+            self.gripper_operation_enabled = False
+            logger.logger.info(
+                f"Gripper operation disabled, operated count: {self.gripper_operated_count}"
+            )
+        self.gripper_operated_count += 1
+
         move_type = (
             "Normal"  # "Normal", "AvoidObs" # Normal is much more fast than AvoidObs
         )
@@ -244,33 +265,37 @@ class CogActDemoEnv(DemoEnv):
         self.robot.move_pose(
             target_left_ee_pose, type=move_type, arm="left", block=True
         )
-
-        # move gripper
-        right_gripper_action = actions["ROBOT_RIGHT_GRIPPER"][0]
-        # right_gripper_action = 0
-        if right_gripper_action > 0.5:
-            # right_gripper_action = "open"
-            # self.robot.set_gripper_action(right_gripper_action, arm="right")
-            # self.robot.open_gripper("right")
-            self._operate_gripper("right", right_gripper_action)
+        
+        if not self.gripper_operation_enabled:
+            logger.logger.warning("Gripper operation is currently disabled.")
+            return
         else:
-            # right_gripper_action = "close"
-            # self.robot.set_gripper_action(right_gripper_action, arm="right")
-            # self.robot.close_gripper("right")
-            logger.logger.info("Close gripper")
-            self._operate_gripper("right", right_gripper_action)
+            # move gripper
+            right_gripper_action = actions["ROBOT_RIGHT_GRIPPER"][0]
+            # right_gripper_action = 0
+            if right_gripper_action > 0.5:
+                # right_gripper_action = "open"
+                # self.robot.set_gripper_action(right_gripper_action, arm="right")
+                # self.robot.open_gripper("right")
+                self._operate_gripper("right", right_gripper_action)
+            else:
+                # right_gripper_action = "close"
+                # self.robot.set_gripper_action(right_gripper_action, arm="right")
+                # self.robot.close_gripper("right")
+                logger.logger.info("Close gripper")
+                self._operate_gripper("right", right_gripper_action)
 
-        left_gripper_action = actions["ROBOT_LEFT_GRIPPER"][0]
-        if left_gripper_action > 0.5:
-            # left_gripper_action = "open"
-            # self.robot.set_gripper_action(left_gripper_action, arm="left")
-            # self.robot.open_gripper("left")
-            self._operate_gripper("left", right_gripper_action)
-        else:
-            # left_gripper_action = "close"
-            # self.robot.set_gripper_action(left_gripper_action, arm="left")
-            # self.robot.close_gripper("left")
-            self._operate_gripper("left", right_gripper_action)
+            left_gripper_action = actions["ROBOT_LEFT_GRIPPER"][0]
+            if left_gripper_action > 0.5:
+                # left_gripper_action = "open"
+                # self.robot.set_gripper_action(left_gripper_action, arm="left")
+                # self.robot.open_gripper("left")
+                self._operate_gripper("left", right_gripper_action)
+            else:
+                # left_gripper_action = "close"
+                # self.robot.set_gripper_action(left_gripper_action, arm="left")
+                # self.robot.close_gripper("left")
+                self._operate_gripper("left", right_gripper_action)
 
     def _operate_gripper(self, gripper_type: str, gripper_value):
         """    def set_init_pose(self, init_pose):
@@ -361,7 +386,7 @@ class CogActDemoEnv(DemoEnv):
 
             # np.arange excludes the endpoint, so we subtract a small epsilon to include min_value
             return np.arange(current_value, min_value - 1e-8, -delta)
-        gentle_closed_postion = 0.01  # Set a gentle close position, e.g., 0.01
+        gentle_closed_postion = 0.1  # Set a gentle close position, e.g., 0.01
         if current_position > gentle_closed_postion:
             gentle_close_positions = generate_decreasing_range(
                 current_value=current_position,
@@ -369,11 +394,15 @@ class CogActDemoEnv(DemoEnv):
                 delta=gentle_close_position_delta
             )
             print(f"Gently closing {gripper_type} gripper in {len(gentle_close_positions)} steps from {current_position} to 0.01 with delta {gentle_close_position_delta}")
-            self.robot.client.set_joint_positions(
-                target_joint_position=gentle_close_positions,
-                is_trajectory=True,
-                joint_indices=[gripper_joint_idx],
-            )
+            for gripper_pos in gentle_close_positions:
+                # Set the gripper position
+                self.robot.client.set_joint_positions(
+                    target_joint_position=[gripper_pos],
+                    is_trajectory=False,
+                    joint_indices=[gripper_joint_idx],
+                )
+                time.sleep(0.05)
+                print(f"{gripper_type} gripper gently closed to {gripper_pos}")
 
     def _get_per_step_actions(self, actions, step_id):
         """
@@ -402,6 +431,7 @@ class CogActDemoEnv(DemoEnv):
         for execute_step_id in range(execute_K):
             is_first_or_last = execute_step_id == 0 or execute_step_id == execute_K - 1
             is_last = execute_step_id == execute_K - 1
+            is_first = execute_step_id == 0
             is_selected_step = (execute_step_id + 1) % execute_step_N == 0
             if not is_first_or_last and not is_selected_step:
                 continue

--- a/scripts/dbg/replay_logging_obs_images.py
+++ b/scripts/dbg/replay_logging_obs_images.py
@@ -8,11 +8,11 @@ from tqdm import tqdm
 # -------- CONFIG --------
 # task_name = "iros_make_a_sandwich"
 # task_name = "iros_clear_table_in_the_restaurant"
-# task_name = "iros_restock_supermarket_items"
+task_name = "iros_restock_supermarket_items"
 # task_name = "iros_stamp_the_seal"
 # task_name = "iros_pack_moving_objects_from_conveyor"
-task_name = "iros_clear_the_countertop_waste"
-EXP_ID="port_7010"
+# task_name = "iros_clear_the_countertop_waste"
+EXP_ID="port_12020"
 BASE_LOG_DIR = (
     f"/root/workspace/main/action_logs/{EXP_ID}/{task_name}"
 )
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         # Mirror output dir path
         video_output_dir = iter_dir.replace(BASE_LOG_DIR, VIDEO_ROOT)
         os.makedirs(video_output_dir, exist_ok=True)
-        output_path = os.path.join(iter_dir, VIDEO_FILENAME)
+        output_path = os.path.join(video_output_dir, VIDEO_FILENAME)
         if os.path.exists(output_path):
             print(f"Skipping {iter_dir} (video already exists)")
             continue


### PR DESCRIPTION
1. set a proper close to most gripper width (avoid squeeze object outside of griper)
2. gentle close logic instead of directly close to most (avoid squeeze object with big force resulting object flying away)
3. set threshold to avoid close gripper per exe, default to 16 (avoid close gripper per control to sequeeze object away)